### PR TITLE
Add support for excluding pattern when pushing folder

### DIFF
--- a/dist/Swiff.js
+++ b/dist/Swiff.js
@@ -37,6 +37,8 @@ var _config = require("./config");
 
 var _palette = require("./palette");
 
+var _process = require("process");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
@@ -440,9 +442,13 @@ class Swiff extends _react.Component {
 
       const hasMissingPaths = yield (0, _utils.getMissingPaths)(filteredPushFolders, 'pushFolders'); // If any local paths are missing then return the messages
 
-      if (hasMissingPaths instanceof Error) return _this.setError(hasMissingPaths); // Share what's happening with the user
+      if (hasMissingPaths instanceof Error) return _this.setError(hasMissingPaths); // Check if push folder option is valid
 
-      _this.setWorking(`Pushing files in ${(0, _utils.commaAmpersander)(filteredPushFolders)}`); // Get the rsync push commands
+      const isPushFolderOptionsValid = (0, _utils.validatePushFolderOptions)(filteredPushFolders, 'pushFolders'); // If any local paths are missing then return the messages
+
+      if (isPushFolderOptionsValid instanceof Error) return _this.setError(isPushFolderOptionsValid); // Share what's happening with the user
+
+      _this.setWorking(`Pushing files in ${(0, _utils.commaAmpersander)(filteredPushFolders.map(f => typeof f === 'string' ? f : f.path))}`); // Get the rsync push commands
 
 
       const pushCommands = (0, _ssh2.getSshPushCommands)({

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -15,7 +15,7 @@ Object.defineProperty(exports, "isEmpty", {
     return _isEmpty.default;
   }
 });
-exports.paginate = exports.replaceRsyncOutput = exports.commaAmpersander = exports.doesFileExist = exports.cmdPromise = exports.getMissingPaths = exports.executeCommands = exports.resolveApp = void 0;
+exports.paginate = exports.replaceRsyncOutput = exports.commaAmpersander = exports.doesFileExist = exports.cmdPromise = exports.validatePushFolderOptions = exports.getMissingPaths = exports.executeCommands = exports.resolveApp = void 0;
 
 var _path = _interopRequireDefault(require("path"));
 
@@ -98,6 +98,10 @@ function () {
         /*#__PURE__*/
         function () {
           var _ref5 = _asyncToGenerator(function* (path) {
+            if (typeof path !== "string") {
+              path = path.path;
+            }
+
             const doesExist = yield doesFileExist(path);
             return doesExist ? null : path;
           });
@@ -130,6 +134,17 @@ function () {
 }();
 
 exports.getMissingPaths = getMissingPaths;
+
+const validatePushFolderOptions = (suppliedPaths, configSetting) => {
+  suppliedPaths.forEach(item => {
+    if (Object.keys(item).filter(k => ['path', 'exclude'].indexOf(k) !== -1).length) {
+      return new Error(`Only 'path' and 'exclude' key is supported in push folders setting. Adjust the ${(0, _palette.colourAttention)(configSetting)} values in your ${(0, _palette.colourAttention)('swiff.config.js')}`);
+    }
+  });
+  return true;
+};
+
+exports.validatePushFolderOptions = validatePushFolderOptions;
 
 const commaAmpersander = (array, styler = _palette.colourHighlight) => array.map((f, i) => (i > 0 ? i === array.length - 1 ? ' and ' : ', ' : '') + styler(f)).join(''); // Check https://stackoverflow.com/a/36851784/9055509 for rsync output details
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "swiff",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "description": "Swiff saves you time with common SSH tasks during the development of websites/apps",
     "main": "index.js",
     "scripts": {

--- a/src/Swiff.js
+++ b/src/Swiff.js
@@ -10,6 +10,7 @@ import {
     isEmpty,
     executeCommands,
     getMissingPaths,
+    validatePushFolderOptions,
     cmdPromise,
     doesFileExist,
     commaAmpersander,
@@ -57,6 +58,7 @@ import {
     colourMuted,
     colourDefault,
 } from './palette'
+import { exit } from 'process'
 
 // Start user analytics for error and usage information
 const visitor = ua('UA-131596357-2')
@@ -611,9 +613,17 @@ class Swiff extends Component {
         // If any local paths are missing then return the messages
         if (hasMissingPaths instanceof Error)
             return this.setError(hasMissingPaths)
+        // Check if push folder option is valid
+        const isPushFolderOptionsValid = validatePushFolderOptions(
+            filteredPushFolders,
+            'pushFolders'
+        );
+        // If any local paths are missing then return the messages
+        if (isPushFolderOptionsValid instanceof Error)
+            return this.setError(isPushFolderOptionsValid)
         // Share what's happening with the user
         this.setWorking(
-            `Pushing files in ${commaAmpersander(filteredPushFolders)}`
+            `Pushing files in ${commaAmpersander(filteredPushFolders.map(f => (typeof f === 'string')?f:f.path))}`
         )
         // Get the rsync push commands
         const pushCommands = getSshPushCommands({

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,6 +29,9 @@ const getMissingPaths = async (suppliedPaths, configSetting) => {
     // Map over the list of paths and return missing ones
     const getResults = async paths => {
         const pathChecks = await paths.map(async path => {
+            if (typeof path !== "string") {
+                path = path.path
+            }
             const doesExist = await doesFileExist(path)
             return doesExist ? null : path
         })
@@ -55,6 +58,17 @@ const getMissingPaths = async (suppliedPaths, configSetting) => {
               )} values in your ${colourAttention('swiff.config.js')}`
           )
         : []
+}
+
+const validatePushFolderOptions = (suppliedPaths, configSetting) => {
+    suppliedPaths.forEach(item => {
+        if (Object.keys(item).filter(k => ['path','exclude'].indexOf(k)!==-1).length) {
+            return new Error(`Only 'path' and 'exclude' key is supported in push folders setting. Adjust the ${colourAttention(
+                configSetting
+            )} values in your ${colourAttention('swiff.config.js')}`);
+        }
+    })
+    return true;
 }
 
 const commaAmpersander = (array, styler = colourHighlight) =>
@@ -167,6 +181,7 @@ export {
     executeCommands,
     promisify,
     getMissingPaths,
+    validatePushFolderOptions,
     cmdPromise,
     doesFileExist,
     commaAmpersander,


### PR DESCRIPTION
After CraftCMS 3.5, using project config is enforced.

Adding ability to exclude pattern when using `swiff` push folder so that project config can be excluded.

So in `swiff.config.js`, instead of

```js
{ pushFolders: [
    'config'
]}
```

We can use 

```js
{ pushFolders: [
    { path: 'config', exclude: 'config/project'}
]}
```